### PR TITLE
changed gitmodules to HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "che-che4z-lsp-for-cobol-integration"]
 	path = che-che4z-lsp-for-cobol-integration
-	url = git@github.com:avishek-sen-gupta/che-che4z-lsp-for-cobol-integration.git
+	url = https://github.com/avishek-sen-gupta/che-che4z-lsp-for-cobol-integration.git
 	branch = poc
 [submodule "woof"]
 	path = woof


### PR DESCRIPTION
This helps simplify running `git _submodule_ update --init --recursive` by not requiring using SSH _and_ HTTPS, which removes the requirement for SSH/privatekeys for a public repo.