### PR TITLE
Fix comment attachment ambiguity for duplicate statement text

### DIFF
--- a/smojol-core/src/main/java/org/smojol/common/ast/CommentBlock.java
+++ b/smojol-core/src/main/java/org/smojol/common/ast/CommentBlock.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class CommentBlock {
     private final List<String> lines = new ArrayList<>();
     @Getter private String codeContextLine;
+    @Getter private int codeContextLineNumber;
     private ParseTree nodeContext;
 
     public void add(String commentLine) {
@@ -17,6 +18,11 @@ public class CommentBlock {
 
     public void setCodeContext(String codeContextLine) {
         this.codeContextLine = codeContextLine.trim();
+    }
+
+    public void setCodeContext(String codeContextLine, int lineNumber) {
+        this.codeContextLine = codeContextLine.trim();
+        this.codeContextLineNumber = lineNumber;
     }
 
     public void setAssociatedTree(ParseTree nodeContext) {

--- a/smojol-core/src/main/java/org/smojol/common/ast/CommentExtraction.java
+++ b/smojol-core/src/main/java/org/smojol/common/ast/CommentExtraction.java
@@ -2,6 +2,7 @@ package org.smojol.common.ast;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.eclipse.lsp.cobol.core.CobolLexer;
 import org.eclipse.lsp.cobol.core.CobolSentenceParser;
@@ -11,7 +12,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class CommentExtraction {
@@ -19,25 +19,38 @@ public class CommentExtraction {
         List<CommentBlock> allCommentBlocks = new ArrayList<>();
         CommentBlock currentBlock = new CommentBlock();
         String[] lineArray = new String(Files.readAllBytes(sourcePath)).split("\n");
-        List<String> lines = Arrays.stream(lineArray).filter(l -> l.length() > 7).toList();
-//        List<String> lines = Files.readAllLines(sourcePath, StandardCharsets.ISO_8859_1)
-//                .stream().filter(l -> l.trim().length() > 7).toList();
-        List<String> linesWithoutAreaA = lines.stream().map(l -> l.substring(6)).toList();
-        for (String line : linesWithoutAreaA) {
+        for (int i = 0; i < lineArray.length; i++) {
+            String rawLine = lineArray[i];
+            if (rawLine.length() <= 7) continue;
+            String line = rawLine.substring(6);
             if (line.startsWith("*")) {
                 if (!containsWords(line)) continue;
                 if (currentBlock == null) currentBlock = new CommentBlock();
                 currentBlock.add(line);
             } else {
                 if (currentBlock == null) continue;
-                currentBlock.setCodeContext(line);
+                currentBlock.setCodeContext(line, i + 1); // 1-based line number to match ANTLR
                 allCommentBlocks.add(currentBlock);
                 currentBlock = null;
             }
         }
 
         allCommentBlocks.forEach(block -> {
-            ParseTree matchingNode = navigator.findNarrowestByCondition(n -> NodeText.originalText(n, NodeText::PASSTHROUGH).contains(block.getCodeContextLine().trim()));
+            ParseTree matchingNode;
+            if (block.getCodeContextLineNumber() > 0) {
+                // Match by line number to avoid ambiguity when identical statements exist
+                matchingNode = navigator.findNarrowestByCondition(n -> {
+                    if (n instanceof ParserRuleContext ctx && ctx.getStart() != null) {
+                        int startLine = ctx.getStart().getLine();
+                        int stopLine = ctx.getStop() != null ? ctx.getStop().getLine() : startLine;
+                        return block.getCodeContextLineNumber() >= startLine && block.getCodeContextLineNumber() <= stopLine;
+                    }
+                    return false;
+                });
+            } else {
+                // Fallback to text-based matching for backward compatibility
+                matchingNode = navigator.findNarrowestByCondition(n -> NodeText.originalText(n, NodeText::PASSTHROUGH).contains(block.getCodeContextLine().trim()));
+            }
             block.setAssociatedTree(matchingNode);
         });
         return allCommentBlocks;

--- a/smojol-toolkit/src/main/java/org/smojol/toolkit/analysis/task/analysis/AttachCommentsTask.java
+++ b/smojol-toolkit/src/main/java/org/smojol/toolkit/analysis/task/analysis/AttachCommentsTask.java
@@ -1,5 +1,7 @@
 package org.smojol.toolkit.analysis.task.analysis;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
 import org.smojol.common.ast.CommentBlock;
 import org.smojol.common.ast.CommentExtraction;
 import org.smojol.common.ast.FlowNode;
@@ -36,7 +38,21 @@ public class AttachCommentsTask implements AnalysisTask {
             List<CommentBlock> commentBlocks = new CommentExtraction().run(sourceConfig.sourcePath(), navigator);
             commentBlocks.forEach(cb -> {
                 LOGGER.finer("Attaching comments");
-                FlowNode node = new FlowNodeNavigator(astRoot).findNarrowestByCondition(n -> n.originalText().contains(cb.getCodeContextLine()));
+                FlowNode node;
+                if (cb.getCodeContextLineNumber() > 0) {
+                    // Match by line number to correctly handle duplicate statement text
+                    node = new FlowNodeNavigator(astRoot).findNarrowestByCondition(n -> {
+                        ParseTree ctx = n.getExecutionContext();
+                        if (ctx instanceof ParserRuleContext prc && prc.getStart() != null) {
+                            int startLine = prc.getStart().getLine();
+                            int stopLine = prc.getStop() != null ? prc.getStop().getLine() : startLine;
+                            return cb.getCodeContextLineNumber() >= startLine && cb.getCodeContextLineNumber() <= stopLine;
+                        }
+                        return false;
+                    });
+                } else {
+                    node = new FlowNodeNavigator(astRoot).findNarrowestByCondition(n -> n.originalText().contains(cb.getCodeContextLine()));
+                }
                 if (node != null) node.addComment(cb);
                 else {
                     CobolDataStructure dataStructure = new DataStructureNavigator(dataStructures).findByCondition(ds -> ds.getRawText().contains(cb.getCodeContextLine()));


### PR DESCRIPTION
When identical COBOL statements appear in multiple paragraphs, text-based matching could attach comments to the wrong node.

Now tracks the physical source line number of each comment's associated code line and matches by ANTLR token line range instead of text content. Falls back to text-based matching when line numbers are unavailable.